### PR TITLE
Small bugfix : elimination of spurious linefeeds.

### DIFF
--- a/patchKnitrSynctex.R
+++ b/patchKnitrSynctex.R
@@ -13,6 +13,7 @@ patchKnitrSynctex <- function (texfile){
 	if (!file.exists(f)) 
 		stop(paste(f,"does not exist! Did you set 'opts_knit$set(concordance = TRUE);'?"))
 	text<-readChar(f, file.info(f)$size);
+	text<-gsub(" \\%\\n"," ",text)
 	require(stringr)
 	re="\\\\Sconcordance\\{concordance:([^:]*):([^\\%]*):\\%\\r?\\n(\\d+)(( \\d+ \\d+)*)\\}";
 	parsed=str_match_all(text,re);


### PR DESCRIPTION
The foo-concordance.tex file resulting from compilation of a
not-so-small foo.tex file may contain spurious " \%\n" groups (in
regexp parlance) which are equivalent to " " fot TeX and friends.

These are a pain to parse with regexps, so the best thong is to purge
them from the buffer before parsing with a swift gsub...

Emmanuel Charpentier, 26-XII-2014
