### PR TITLE
trim `re` to get >0 matches from `str_match_all`

### DIFF
--- a/patchKnitrSynctex.R
+++ b/patchKnitrSynctex.R
@@ -14,7 +14,7 @@ patchKnitrSynctex <- function (texfile){
 		stop(paste(f,"does not exist! Did you set 'opts_knit$set(concordance = TRUE);'?"))
 	text<-readChar(f, file.info(f)$size);
 	require(stringr)
-	re="\\\\Sconcordance\\{concordance:([^:]*):([^\\%]*):\\%\\r?\\n(\\d+)(( \\d+ \\d+)*)\\}";
+	re="\\\\Sconcordance\\{concordance:([^:]*):([^\\%]*):\\%\\r?\\n(\\d+)(( \\d+ \\d+)*)";
 	parsed=str_match_all(text,re);
 	for(i in seq(1,nrow(parsed[[1]]))){		
 		texF=parsed[[1]][i,2];

--- a/patchKnitrSynctex.R
+++ b/patchKnitrSynctex.R
@@ -14,15 +14,16 @@ patchKnitrSynctex <- function (texfile){
 		stop(paste(f,"does not exist! Did you set 'opts_knit$set(concordance = TRUE);'?"))
 	text<-readChar(f, file.info(f)$size);
 	require(stringr)
-#    re="\\\\Sconcordance\\{concordance:([^:]*):([^\\%]*):\\%\\r?\\n(\\d+)(( \\d+ \\d+)*)"
 	re="\\\\Sconcordance\\{concordance:([^:]*):([^\\%]*):\\%\\r?\\n(\\d+ )((\\d+ \\d+[ \\}]\\%?\\r?\\n?)*)";
 	parsed=str_match_all(text,re);
-#	return(parsed)
-    for(i in seq(1,nrow(parsed[[1]]))){		
+	for(i in seq(1,nrow(parsed[[1]]))){		
 		texF=parsed[[1]][i,2];
 		rnwF=parsed[[1]][i,3];
 		startLine=as.integer(parsed[[1]][i,4]);
-		rleValues <- read.table(textConnection(parsed[[1]][i,5]));
+		# Clean newlines and braces from the line concordance data
+		parsedi5_clean <- gsub('[^[:digit:] ]', '', parsed[[1]][i,5])
+		# Coerce cleaned line concordance data to table of values
+		rleValues <- read.table(textConnection(parsedi5_clean));
 		rleO = rle(0);
 		rleO$values=as.numeric(rleValues[seq(2,length(rleValues),2)]);
 		rleO$lengths=as.integer(rleValues[seq(1,length(rleValues),2)]);

--- a/patchKnitrSynctex.R
+++ b/patchKnitrSynctex.R
@@ -14,9 +14,11 @@ patchKnitrSynctex <- function (texfile){
 		stop(paste(f,"does not exist! Did you set 'opts_knit$set(concordance = TRUE);'?"))
 	text<-readChar(f, file.info(f)$size);
 	require(stringr)
-	re="\\\\Sconcordance\\{concordance:([^:]*):([^\\%]*):\\%\\r?\\n(\\d+)(( \\d+ \\d+)*)";
+#    re="\\\\Sconcordance\\{concordance:([^:]*):([^\\%]*):\\%\\r?\\n(\\d+)(( \\d+ \\d+)*)"
+	re="\\\\Sconcordance\\{concordance:([^:]*):([^\\%]*):\\%\\r?\\n(\\d+ )((\\d+ \\d+[ \\}]\\%?\\r?\\n?)*)";
 	parsed=str_match_all(text,re);
-	for(i in seq(1,nrow(parsed[[1]]))){		
+#	return(parsed)
+    for(i in seq(1,nrow(parsed[[1]]))){		
 		texF=parsed[[1]][i,2];
 		rnwF=parsed[[1]][i,3];
 		startLine=as.integer(parsed[[1]][i,4]);


### PR DESCRIPTION
`str_match_all` was returning 0 matches.  The problem seems to be the final `\\}` in the regular expression `re`; after removing these characters everything worked as expected (including Synctex and command-clicking in TeXShop).  
